### PR TITLE
[codex] Fix FF14 release metadata and search races

### DIFF
--- a/SaddlebagExchange/SaddlebagExchange.csproj
+++ b/SaddlebagExchange/SaddlebagExchange.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Dalamud.NET.Sdk/15.0.0">
 
   <PropertyGroup>
-    <Version>1.0.16</Version>
+    <Version>1.0.19</Version>
     <PackageProjectUrl>https://github.com/ff14-advanced-market-search/SaddlebagExchangeMarketboardPlugin</PackageProjectUrl>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SaddlebagExchange/UI/CraftsimTab.cs
+++ b/SaddlebagExchange/UI/CraftsimTab.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
@@ -26,6 +27,7 @@ namespace SaddlebagExchange.UI
         private bool _showJobsPopup;
         private CraftsimResultsWindow? _resultsWindow;
         private volatile bool _requestOpenResultsWindow;
+        private int _scanGeneration;
         private int _sortColumnIndex = -1;
         private bool _sortAscending = true;
         private bool _showColumnsPopup;
@@ -537,6 +539,7 @@ namespace SaddlebagExchange.UI
 
         private void StartScan()
         {
+            var scanGeneration = Interlocked.Increment(ref _scanGeneration);
             _params.HomeServer = _homeServerBuffer.Trim();
             if (string.IsNullOrEmpty(_params.HomeServer))
             {
@@ -567,12 +570,16 @@ namespace SaddlebagExchange.UI
                 try
                 {
                     var list = await _api.CraftsimAsync(paramsCopy).ConfigureAwait(false);
+                    if (scanGeneration != Volatile.Read(ref _scanGeneration))
+                        return;
                     var results = (list ?? new List<CraftsimResultItem>()).ToImmutableArray();
                     _state = new ScanState<CraftsimResultItem>(false, results, string.Empty);
                     if (results.Length > 0) _requestOpenResultsWindow = true;
                 }
                 catch (Exception ex)
                 {
+                    if (scanGeneration != Volatile.Read(ref _scanGeneration))
+                        return;
                     _state = new ScanState<CraftsimResultItem>(false, ImmutableArray<CraftsimResultItem>.Empty, ex.Message);
                 }
             });
@@ -954,7 +961,11 @@ namespace SaddlebagExchange.UI
             Util.OpenLink(url);
         }
 
-        public void Dispose() => _api.Dispose();
+        public void Dispose()
+        {
+            Interlocked.Increment(ref _scanGeneration);
+            _api.Dispose();
+        }
 
         private sealed record ScanState<T>(bool Loading, ImmutableArray<T> Results, string Error)
         {

--- a/SaddlebagExchange/UI/CraftsimTab.cs
+++ b/SaddlebagExchange/UI/CraftsimTab.cs
@@ -544,13 +544,14 @@ namespace SaddlebagExchange.UI
             CraftsimParams paramsCopy;
             lock (_scanLock)
             {
-                scanGeneration = ++_scanGeneration;
                 _params.HomeServer = _homeServerBuffer.Trim();
                 if (string.IsNullOrEmpty(_params.HomeServer))
                 {
-                    _state = _state with { Error = "Set Home server first." };
+                    _state = _state with { Loading = false, Error = "Set Home server first." };
                     return;
                 }
+
+                scanGeneration = ++_scanGeneration;
 
                 paramsCopy = new CraftsimParams
                 {

--- a/SaddlebagExchange/UI/CraftsimTab.cs
+++ b/SaddlebagExchange/UI/CraftsimTab.cs
@@ -27,6 +27,7 @@ namespace SaddlebagExchange.UI
         private bool _showJobsPopup;
         private CraftsimResultsWindow? _resultsWindow;
         private volatile bool _requestOpenResultsWindow;
+        private readonly object _scanLock = new();
         private int _scanGeneration;
         private int _sortColumnIndex = -1;
         private bool _sortAscending = true;
@@ -539,48 +540,59 @@ namespace SaddlebagExchange.UI
 
         private void StartScan()
         {
-            var scanGeneration = Interlocked.Increment(ref _scanGeneration);
-            _params.HomeServer = _homeServerBuffer.Trim();
-            if (string.IsNullOrEmpty(_params.HomeServer))
+            int scanGeneration;
+            CraftsimParams paramsCopy;
+            lock (_scanLock)
             {
-                _state = _state with { Error = "Set Home server first." };
-                return;
+                scanGeneration = ++_scanGeneration;
+                _params.HomeServer = _homeServerBuffer.Trim();
+                if (string.IsNullOrEmpty(_params.HomeServer))
+                {
+                    _state = _state with { Error = "Set Home server first." };
+                    return;
+                }
+
+                paramsCopy = new CraftsimParams
+                {
+                    HomeServer = _params.HomeServer,
+                    CostMetric = _params.CostMetric,
+                    RevenueMetric = _params.RevenueMetric,
+                    SalesPerWeek = _params.SalesPerWeek,
+                    MedianSalePrice = _params.MedianSalePrice,
+                    MaxMaterialCost = _params.MaxMaterialCost,
+                    Jobs = _params.Jobs?.ToArray() ?? new[] { 0 },
+                    Filters = _params.Filters?.ToArray() ?? new[] { 0, -5 },
+                    Stars = _params.Stars,
+                    LvlLowerLimit = _params.LvlLowerLimit,
+                    LvlUpperLimit = _params.LvlUpperLimit,
+                    Yields = _params.Yields,
+                    HideExpertRecipes = _params.HideExpertRecipes
+                };
+
+                _state = _state with { Loading = true, Error = string.Empty };
             }
-
-            var paramsCopy = new CraftsimParams
-            {
-                HomeServer = _params.HomeServer,
-                CostMetric = _params.CostMetric,
-                RevenueMetric = _params.RevenueMetric,
-                SalesPerWeek = _params.SalesPerWeek,
-                MedianSalePrice = _params.MedianSalePrice,
-                MaxMaterialCost = _params.MaxMaterialCost,
-                Jobs = _params.Jobs?.ToArray() ?? new[] { 0 },
-                Filters = _params.Filters?.ToArray() ?? new[] { 0, -5 },
-                Stars = _params.Stars,
-                LvlLowerLimit = _params.LvlLowerLimit,
-                LvlUpperLimit = _params.LvlUpperLimit,
-                Yields = _params.Yields,
-                HideExpertRecipes = _params.HideExpertRecipes
-            };
-
-            _state = _state with { Loading = true, Error = string.Empty };
             _ = Task.Run(async () =>
             {
                 try
                 {
                     var list = await _api.CraftsimAsync(paramsCopy).ConfigureAwait(false);
-                    if (scanGeneration != Volatile.Read(ref _scanGeneration))
-                        return;
                     var results = (list ?? new List<CraftsimResultItem>()).ToImmutableArray();
-                    _state = new ScanState<CraftsimResultItem>(false, results, string.Empty);
-                    if (results.Length > 0) _requestOpenResultsWindow = true;
+                    lock (_scanLock)
+                    {
+                        if (scanGeneration != Volatile.Read(ref _scanGeneration))
+                            return;
+                        _state = new ScanState<CraftsimResultItem>(false, results, string.Empty);
+                        if (results.Length > 0) _requestOpenResultsWindow = true;
+                    }
                 }
                 catch (Exception ex)
                 {
-                    if (scanGeneration != Volatile.Read(ref _scanGeneration))
-                        return;
-                    _state = new ScanState<CraftsimResultItem>(false, ImmutableArray<CraftsimResultItem>.Empty, ex.Message);
+                    lock (_scanLock)
+                    {
+                        if (scanGeneration != Volatile.Read(ref _scanGeneration))
+                            return;
+                        _state = new ScanState<CraftsimResultItem>(false, ImmutableArray<CraftsimResultItem>.Empty, ex.Message);
+                    }
                 }
             });
         }
@@ -963,7 +975,10 @@ namespace SaddlebagExchange.UI
 
         public void Dispose()
         {
-            Interlocked.Increment(ref _scanGeneration);
+            lock (_scanLock)
+            {
+                _scanGeneration++;
+            }
             _api.Dispose();
         }
 

--- a/SaddlebagExchange/UI/MarketshareTab.cs
+++ b/SaddlebagExchange/UI/MarketshareTab.cs
@@ -34,6 +34,7 @@ namespace SaddlebagExchange.UI
         private MarketshareResultsWindow? _resultsWindow;
         private volatile bool _requestOpenResultsWindow;
         private MarketshareTreemapWindow? _treemapWindow;
+        private int _scanGeneration;
         private int _treemapMetricIndex;
         private bool _showColumnsPopup;
         private readonly byte[] _searchBuffer = new byte[SearchBufferSize];
@@ -811,6 +812,7 @@ namespace SaddlebagExchange.UI
 
         private void StartScan()
         {
+            var scanGeneration = Interlocked.Increment(ref _scanGeneration);
             _params.Server = _params.Server.Trim();
             if (string.IsNullOrEmpty(_params.Server))
             {
@@ -831,19 +833,27 @@ namespace SaddlebagExchange.UI
             {
                 try
                 {
-                    var list = await _api.MarketshareAsync(paramsCopy, CancellationToken.None).ConfigureAwait(false);
+                    var list = await _api.MarketshareAsync(paramsCopy).ConfigureAwait(false);
+                    if (scanGeneration != Volatile.Read(ref _scanGeneration))
+                        return;
                     var results = (list ?? new List<MarketshareResultItem>()).ToImmutableArray();
                     _state = new ScanState<MarketshareResultItem>(false, results, string.Empty);
                     if (results.Length > 0) _requestOpenResultsWindow = true;
                 }
                 catch (Exception ex)
                 {
+                    if (scanGeneration != Volatile.Read(ref _scanGeneration))
+                        return;
                     _state = new ScanState<MarketshareResultItem>(false, ImmutableArray<MarketshareResultItem>.Empty, ex.Message);
                 }
             });
         }
 
-        public void Dispose() => _api.Dispose();
+        public void Dispose()
+        {
+            Interlocked.Increment(ref _scanGeneration);
+            _api.Dispose();
+        }
 
         private sealed record ScanState<T>(bool Loading, ImmutableArray<T> Results, string Error)
         {

--- a/SaddlebagExchange/UI/MarketshareTab.cs
+++ b/SaddlebagExchange/UI/MarketshareTab.cs
@@ -817,13 +817,15 @@ namespace SaddlebagExchange.UI
             MarketshareParams paramsCopy;
             lock (_scanLock)
             {
-                scanGeneration = ++_scanGeneration;
                 _params.Server = _params.Server.Trim();
                 if (string.IsNullOrEmpty(_params.Server))
                 {
-                    _state = _state with { Error = "Set World first." };
+                    _state = _state with { Loading = false, Error = "Set World first." };
                     return;
                 }
+
+                scanGeneration = ++_scanGeneration;
+
                 paramsCopy = new MarketshareParams
                 {
                     Server = _params.Server,

--- a/SaddlebagExchange/UI/MarketshareTab.cs
+++ b/SaddlebagExchange/UI/MarketshareTab.cs
@@ -34,6 +34,7 @@ namespace SaddlebagExchange.UI
         private MarketshareResultsWindow? _resultsWindow;
         private volatile bool _requestOpenResultsWindow;
         private MarketshareTreemapWindow? _treemapWindow;
+        private readonly object _scanLock = new();
         private int _scanGeneration;
         private int _treemapMetricIndex;
         private bool _showColumnsPopup;
@@ -812,46 +813,60 @@ namespace SaddlebagExchange.UI
 
         private void StartScan()
         {
-            var scanGeneration = Interlocked.Increment(ref _scanGeneration);
-            _params.Server = _params.Server.Trim();
-            if (string.IsNullOrEmpty(_params.Server))
+            int scanGeneration;
+            MarketshareParams paramsCopy;
+            lock (_scanLock)
             {
-                _state = _state with { Error = "Set World first." };
-                return;
+                scanGeneration = ++_scanGeneration;
+                _params.Server = _params.Server.Trim();
+                if (string.IsNullOrEmpty(_params.Server))
+                {
+                    _state = _state with { Error = "Set World first." };
+                    return;
+                }
+                paramsCopy = new MarketshareParams
+                {
+                    Server = _params.Server,
+                    TimePeriod = _params.TimePeriod,
+                    SalesAmount = _params.SalesAmount,
+                    AveragePrice = _params.AveragePrice,
+                    Filters = _params.Filters?.ToArray() ?? Array.Empty<int>(),
+                    SortBy = _params.SortBy
+                };
+                _state = _state with { Loading = true, Error = string.Empty };
             }
-            var paramsCopy = new MarketshareParams
-            {
-                Server = _params.Server,
-                TimePeriod = _params.TimePeriod,
-                SalesAmount = _params.SalesAmount,
-                AveragePrice = _params.AveragePrice,
-                Filters = _params.Filters?.ToArray() ?? Array.Empty<int>(),
-                SortBy = _params.SortBy
-            };
-            _state = _state with { Loading = true, Error = string.Empty };
             _ = Task.Run(async () =>
             {
                 try
                 {
                     var list = await _api.MarketshareAsync(paramsCopy).ConfigureAwait(false);
-                    if (scanGeneration != Volatile.Read(ref _scanGeneration))
-                        return;
                     var results = (list ?? new List<MarketshareResultItem>()).ToImmutableArray();
-                    _state = new ScanState<MarketshareResultItem>(false, results, string.Empty);
-                    if (results.Length > 0) _requestOpenResultsWindow = true;
+                    lock (_scanLock)
+                    {
+                        if (scanGeneration != Volatile.Read(ref _scanGeneration))
+                            return;
+                        _state = new ScanState<MarketshareResultItem>(false, results, string.Empty);
+                        if (results.Length > 0) _requestOpenResultsWindow = true;
+                    }
                 }
                 catch (Exception ex)
                 {
-                    if (scanGeneration != Volatile.Read(ref _scanGeneration))
-                        return;
-                    _state = new ScanState<MarketshareResultItem>(false, ImmutableArray<MarketshareResultItem>.Empty, ex.Message);
+                    lock (_scanLock)
+                    {
+                        if (scanGeneration != Volatile.Read(ref _scanGeneration))
+                            return;
+                        _state = new ScanState<MarketshareResultItem>(false, ImmutableArray<MarketshareResultItem>.Empty, ex.Message);
+                    }
                 }
             });
         }
 
         public void Dispose()
         {
-            Interlocked.Increment(ref _scanGeneration);
+            lock (_scanLock)
+            {
+                _scanGeneration++;
+            }
             _api.Dispose();
         }
 

--- a/SaddlebagExchange/UI/ResellingSearchTab.cs
+++ b/SaddlebagExchange/UI/ResellingSearchTab.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
@@ -29,6 +30,7 @@ namespace SaddlebagExchange.UI
         private bool _showFiltersPopup;
         private string _selectedDataCenter = string.Empty;
         private const int SearchBufferSize = 128;
+        private int _scanGeneration;
         private readonly byte[] _searchBuffer = new byte[SearchBufferSize];
         private int _tableIdCounter;
         private string? _copyNotificationText;
@@ -463,6 +465,7 @@ namespace SaddlebagExchange.UI
 
         private void StartScan()
         {
+            var scanGeneration = Interlocked.Increment(ref _scanGeneration);
             _params.HomeServer = _homeServerBuffer.Trim();
             if (string.IsNullOrEmpty(_params.HomeServer))
             {
@@ -490,12 +493,16 @@ namespace SaddlebagExchange.UI
                 try
                 {
                     var list = await _api.ScanAsync(paramsCopy).ConfigureAwait(false);
+                    if (scanGeneration != Volatile.Read(ref _scanGeneration))
+                        return;
                     var results = (list ?? new List<ResellingResultItem>()).ToImmutableArray();
                     _state = new ScanState<ResellingResultItem>(false, results, string.Empty);
                     if (results.Length > 0) _requestOpenResultsWindow = true;
                 }
                 catch (Exception ex)
                 {
+                    if (scanGeneration != Volatile.Read(ref _scanGeneration))
+                        return;
                     _state = new ScanState<ResellingResultItem>(false, ImmutableArray<ResellingResultItem>.Empty, ex.Message);
                 }
             });
@@ -849,7 +856,11 @@ namespace SaddlebagExchange.UI
             return list;
         }
 
-        public void Dispose() => _api.Dispose();
+        public void Dispose()
+        {
+            Interlocked.Increment(ref _scanGeneration);
+            _api.Dispose();
+        }
 
         private sealed record ScanState<T>(bool Loading, ImmutableArray<T> Results, string Error)
         {

--- a/SaddlebagExchange/UI/ResellingSearchTab.cs
+++ b/SaddlebagExchange/UI/ResellingSearchTab.cs
@@ -30,6 +30,7 @@ namespace SaddlebagExchange.UI
         private bool _showFiltersPopup;
         private string _selectedDataCenter = string.Empty;
         private const int SearchBufferSize = 128;
+        private readonly object _scanLock = new();
         private int _scanGeneration;
         private readonly byte[] _searchBuffer = new byte[SearchBufferSize];
         private int _tableIdCounter;
@@ -465,45 +466,56 @@ namespace SaddlebagExchange.UI
 
         private void StartScan()
         {
-            var scanGeneration = Interlocked.Increment(ref _scanGeneration);
-            _params.HomeServer = _homeServerBuffer.Trim();
-            if (string.IsNullOrEmpty(_params.HomeServer))
+            int scanGeneration;
+            ResellingParams paramsCopy;
+            lock (_scanLock)
             {
-                _state = _state with { Error = "Set Home server first." };
-                return;
+                scanGeneration = ++_scanGeneration;
+                _params.HomeServer = _homeServerBuffer.Trim();
+                if (string.IsNullOrEmpty(_params.HomeServer))
+                {
+                    _state = _state with { Error = "Set Home server first." };
+                    return;
+                }
+                paramsCopy = new ResellingParams
+                {
+                    PreferredRoi = _params.PreferredRoi,
+                    MinProfitAmount = _params.MinProfitAmount,
+                    MinDesiredAvgPpu = _params.MinDesiredAvgPpu,
+                    MinStackSize = _params.MinStackSize,
+                    HoursAgo = _params.HoursAgo,
+                    MinSales = _params.MinSales,
+                    Hq = _params.Hq,
+                    HomeServer = _params.HomeServer,
+                    Filters = _params.Filters?.ToArray() ?? Array.Empty<int>(),
+                    RegionWide = _params.RegionWide,
+                    IncludeVendor = _params.IncludeVendor,
+                    ShowOutStock = _params.ShowOutStock
+                };
+                _state = _state with { Loading = true, Error = string.Empty };
             }
-            var paramsCopy = new ResellingParams
-            {
-                PreferredRoi = _params.PreferredRoi,
-                MinProfitAmount = _params.MinProfitAmount,
-                MinDesiredAvgPpu = _params.MinDesiredAvgPpu,
-                MinStackSize = _params.MinStackSize,
-                HoursAgo = _params.HoursAgo,
-                MinSales = _params.MinSales,
-                Hq = _params.Hq,
-                HomeServer = _params.HomeServer,
-                Filters = _params.Filters?.ToArray() ?? Array.Empty<int>(),
-                RegionWide = _params.RegionWide,
-                IncludeVendor = _params.IncludeVendor,
-                ShowOutStock = _params.ShowOutStock
-            };
-            _state = _state with { Loading = true, Error = string.Empty };
             _ = Task.Run(async () =>
             {
                 try
                 {
                     var list = await _api.ScanAsync(paramsCopy).ConfigureAwait(false);
-                    if (scanGeneration != Volatile.Read(ref _scanGeneration))
-                        return;
                     var results = (list ?? new List<ResellingResultItem>()).ToImmutableArray();
-                    _state = new ScanState<ResellingResultItem>(false, results, string.Empty);
-                    if (results.Length > 0) _requestOpenResultsWindow = true;
+                    lock (_scanLock)
+                    {
+                        if (scanGeneration != Volatile.Read(ref _scanGeneration))
+                            return;
+                        _state = new ScanState<ResellingResultItem>(false, results, string.Empty);
+                        if (results.Length > 0) _requestOpenResultsWindow = true;
+                    }
                 }
                 catch (Exception ex)
                 {
-                    if (scanGeneration != Volatile.Read(ref _scanGeneration))
-                        return;
-                    _state = new ScanState<ResellingResultItem>(false, ImmutableArray<ResellingResultItem>.Empty, ex.Message);
+                    lock (_scanLock)
+                    {
+                        if (scanGeneration != Volatile.Read(ref _scanGeneration))
+                            return;
+                        _state = new ScanState<ResellingResultItem>(false, ImmutableArray<ResellingResultItem>.Empty, ex.Message);
+                    }
                 }
             });
         }
@@ -858,7 +870,10 @@ namespace SaddlebagExchange.UI
 
         public void Dispose()
         {
-            Interlocked.Increment(ref _scanGeneration);
+            lock (_scanLock)
+            {
+                _scanGeneration++;
+            }
             _api.Dispose();
         }
 

--- a/SaddlebagExchange/UI/ResellingSearchTab.cs
+++ b/SaddlebagExchange/UI/ResellingSearchTab.cs
@@ -470,13 +470,15 @@ namespace SaddlebagExchange.UI
             ResellingParams paramsCopy;
             lock (_scanLock)
             {
-                scanGeneration = ++_scanGeneration;
                 _params.HomeServer = _homeServerBuffer.Trim();
                 if (string.IsNullOrEmpty(_params.HomeServer))
                 {
-                    _state = _state with { Error = "Set Home server first." };
+                    _state = _state with { Loading = false, Error = "Set Home server first." };
                     return;
                 }
+
+                scanGeneration = ++_scanGeneration;
+
                 paramsCopy = new ResellingParams
                 {
                     PreferredRoi = _params.PreferredRoi,

--- a/SaddlebagExchange/UI/ShoppingListTab.cs
+++ b/SaddlebagExchange/UI/ShoppingListTab.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
@@ -29,6 +30,7 @@ namespace SaddlebagExchange.UI
         private bool _regionWide;
         private ShoppingListResultsWindow? _resultsWindow;
         private volatile bool _requestOpenResultsWindow;
+        private int _searchGeneration;
         private readonly byte[] _searchBuffer = new byte[SearchBufferSize];
         private int _sortColumnIndex = -1;
         private bool _sortAscending = true;
@@ -518,6 +520,7 @@ namespace SaddlebagExchange.UI
 
         private void StartSearch()
         {
+            var searchGeneration = Interlocked.Increment(ref _searchGeneration);
             var homeServer = (_homeServerBuffer ?? string.Empty).Trim();
             if (string.IsNullOrEmpty(homeServer))
             {
@@ -549,12 +552,16 @@ namespace SaddlebagExchange.UI
                 try
                 {
                     var response = await _api.ShoppingListAsync(paramsCopy).ConfigureAwait(false);
+                    if (searchGeneration != Volatile.Read(ref _searchGeneration))
+                        return;
                     var results = (response.Data ?? []).ToImmutableArray();
                     _state = new ScanState(false, results, string.Empty, response.AverageCostPerCraft, response.TotalCost);
                     if (results.Length > 0) _requestOpenResultsWindow = true;
                 }
                 catch (Exception ex)
                 {
+                    if (searchGeneration != Volatile.Read(ref _searchGeneration))
+                        return;
                     _state = new ScanState(false, ImmutableArray<ShoppingListResultItem>.Empty, ex.Message, 0, 0);
                 }
             });
@@ -588,7 +595,11 @@ namespace SaddlebagExchange.UI
                 ImGui.SetTooltip(tooltip);
         }
 
-        public void Dispose() => _api.Dispose();
+        public void Dispose()
+        {
+            Interlocked.Increment(ref _searchGeneration);
+            _api.Dispose();
+        }
 
         private readonly record struct SearchItemEntry(int ItemId, string Name);
 

--- a/SaddlebagExchange/UI/ShoppingListTab.cs
+++ b/SaddlebagExchange/UI/ShoppingListTab.cs
@@ -30,6 +30,7 @@ namespace SaddlebagExchange.UI
         private bool _regionWide;
         private ShoppingListResultsWindow? _resultsWindow;
         private volatile bool _requestOpenResultsWindow;
+        private readonly object _searchLock = new();
         private int _searchGeneration;
         private readonly byte[] _searchBuffer = new byte[SearchBufferSize];
         private int _sortColumnIndex = -1;
@@ -520,49 +521,60 @@ namespace SaddlebagExchange.UI
 
         private void StartSearch()
         {
-            var searchGeneration = Interlocked.Increment(ref _searchGeneration);
-            var homeServer = (_homeServerBuffer ?? string.Empty).Trim();
-            if (string.IsNullOrEmpty(homeServer))
+            int searchGeneration;
+            ShoppingListParams paramsCopy;
+            lock (_searchLock)
             {
-                _state = _state with { Error = "Set Home server first." };
-                return;
-            }
-            if (_shoppingList.Count == 0)
-            {
-                _state = _state with { Error = "Add at least one item." };
-                return;
-            }
-
-            var paramsCopy = new ShoppingListParams
-            {
-                HomeServer = homeServer,
-                RegionWide = _regionWide,
-                ShoppingList = _shoppingList.Select(x => new ShoppingInputItem
+                searchGeneration = ++_searchGeneration;
+                var homeServer = (_homeServerBuffer ?? string.Empty).Trim();
+                if (string.IsNullOrEmpty(homeServer))
                 {
-                    ItemId = x.ItemId,
-                    CraftAmount = Math.Max(1, x.CraftAmount),
-                    Hq = x.Hq,
-                    Job = x.Job
-                }).ToArray()
-            };
+                    _state = _state with { Error = "Set Home server first." };
+                    return;
+                }
+                if (_shoppingList.Count == 0)
+                {
+                    _state = _state with { Error = "Add at least one item." };
+                    return;
+                }
 
-            _state = _state with { Loading = true, Error = string.Empty };
+                paramsCopy = new ShoppingListParams
+                {
+                    HomeServer = homeServer,
+                    RegionWide = _regionWide,
+                    ShoppingList = _shoppingList.Select(x => new ShoppingInputItem
+                    {
+                        ItemId = x.ItemId,
+                        CraftAmount = Math.Max(1, x.CraftAmount),
+                        Hq = x.Hq,
+                        Job = x.Job
+                    }).ToArray()
+                };
+
+                _state = _state with { Loading = true, Error = string.Empty };
+            }
             _ = Task.Run(async () =>
             {
                 try
                 {
                     var response = await _api.ShoppingListAsync(paramsCopy).ConfigureAwait(false);
-                    if (searchGeneration != Volatile.Read(ref _searchGeneration))
-                        return;
                     var results = (response.Data ?? []).ToImmutableArray();
-                    _state = new ScanState(false, results, string.Empty, response.AverageCostPerCraft, response.TotalCost);
-                    if (results.Length > 0) _requestOpenResultsWindow = true;
+                    lock (_searchLock)
+                    {
+                        if (searchGeneration != Volatile.Read(ref _searchGeneration))
+                            return;
+                        _state = new ScanState(false, results, string.Empty, response.AverageCostPerCraft, response.TotalCost);
+                        if (results.Length > 0) _requestOpenResultsWindow = true;
+                    }
                 }
                 catch (Exception ex)
                 {
-                    if (searchGeneration != Volatile.Read(ref _searchGeneration))
-                        return;
-                    _state = new ScanState(false, ImmutableArray<ShoppingListResultItem>.Empty, ex.Message, 0, 0);
+                    lock (_searchLock)
+                    {
+                        if (searchGeneration != Volatile.Read(ref _searchGeneration))
+                            return;
+                        _state = new ScanState(false, ImmutableArray<ShoppingListResultItem>.Empty, ex.Message, 0, 0);
+                    }
                 }
             });
         }
@@ -597,7 +609,10 @@ namespace SaddlebagExchange.UI
 
         public void Dispose()
         {
-            Interlocked.Increment(ref _searchGeneration);
+            lock (_searchLock)
+            {
+                _searchGeneration++;
+            }
             _api.Dispose();
         }
 

--- a/SaddlebagExchange/UI/ShoppingListTab.cs
+++ b/SaddlebagExchange/UI/ShoppingListTab.cs
@@ -525,18 +525,19 @@ namespace SaddlebagExchange.UI
             ShoppingListParams paramsCopy;
             lock (_searchLock)
             {
-                searchGeneration = ++_searchGeneration;
                 var homeServer = (_homeServerBuffer ?? string.Empty).Trim();
                 if (string.IsNullOrEmpty(homeServer))
                 {
-                    _state = _state with { Error = "Set Home server first." };
+                    _state = _state with { Loading = false, Error = "Set Home server first." };
                     return;
                 }
                 if (_shoppingList.Count == 0)
                 {
-                    _state = _state with { Error = "Add at least one item." };
+                    _state = _state with { Loading = false, Error = "Add at least one item." };
                     return;
                 }
+
+                searchGeneration = ++_searchGeneration;
 
                 paramsCopy = new ShoppingListParams
                 {

--- a/repo.json
+++ b/repo.json
@@ -8,7 +8,7 @@
     "AssemblyVersion": "1.0.19",
     "RepoUrl": "https://github.com/ff14-advanced-market-search/SaddlebagExchangeMarketboardPlugin",
     "ApplicableVersion": "any",
-    "DalamudApiLevel": 14,
+    "DalamudApiLevel": 15,
     "DownloadLinkInstall": "https://github.com/ff14-advanced-market-search/SaddlebagExchangeMarketboardPlugin/releases/latest/download/SaddlebagExchange.zip",
     "IsHide": false,
     "IsTestingExclusive": false,

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -32,13 +32,27 @@ foreach ($p in $csprojPath, $repoJsonPath, $manifestPath) {
 
 # 1) Bump version in csproj
 $csproj = Get-Content $csprojPath -Raw
-$csproj = $csproj -replace '(<AssemblyVersion>)[^<]+(</AssemblyVersion>)', "`${1}$Version`$2"
+if ($csproj -match '<Version>[^<]+</Version>') {
+    $csproj = $csproj -replace '(<Version>)[^<]+(</Version>)', "`${1}$Version`$2"
+    $versionProperty = "Version"
+} elseif ($csproj -match '<AssemblyVersion>[^<]+</AssemblyVersion>') {
+    $csproj = $csproj -replace '(<AssemblyVersion>)[^<]+(</AssemblyVersion>)', "`${1}$Version`$2"
+    $versionProperty = "AssemblyVersion"
+} else {
+    Write-Error "Could not find <Version> or <AssemblyVersion> in $csprojPath"
+    exit 1
+}
 Set-Content $csprojPath -Value $csproj -NoNewline
-Write-Output "Set SaddlebagExchange.csproj AssemblyVersion to $Version"
+Write-Output "Set SaddlebagExchange.csproj $versionProperty to $Version"
 
-# 2) Bump version and LastUpdated in repo.json
+# 2) Bump version, API level, and LastUpdated in repo.json
 $repoJson = Get-Content $repoJsonPath -Raw
 $repoJson = $repoJson -replace '("AssemblyVersion":\s*")[^"]+(")', "`${1}$Version`$2"
+if ($csproj -match 'Dalamud\.NET\.Sdk/(\d+)\.') {
+    $apiLevel = $Matches[1]
+    $repoJson = $repoJson -replace '("DalamudApiLevel":\s*)\d+', "`${1}$apiLevel"
+    Write-Output "Set repo.json DalamudApiLevel to $apiLevel"
+}
 $unixNow = [long]([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())
 $repoJson = $repoJson -replace '("LastUpdated":\s*)\d+', "`${1}$unixNow"
 Set-Content $repoJsonPath -Value $repoJson -NoNewline

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -50,9 +50,21 @@ $repoJson = Get-Content $repoJsonPath -Raw
 $repoJson = $repoJson -replace '("AssemblyVersion":\s*")[^"]+(")', "`${1}$Version`$2"
 if ($csproj -match 'Dalamud\.NET\.Sdk/(\d+)\.') {
     $apiLevel = $Matches[1]
-    $repoJson = $repoJson -replace '("DalamudApiLevel":\s*)\d+', "`${1}$apiLevel"
-    Write-Output "Set repo.json DalamudApiLevel to $apiLevel"
+} else {
+    Write-Error "Could not derive DalamudApiLevel from Dalamud.NET.Sdk in $csprojPath"
+    exit 1
 }
+$repoJson = $repoJson -replace '("DalamudApiLevel":\s*)\d+', "`${1}$apiLevel"
+if ($repoJson -match '"DalamudApiLevel":\s*(\d+)') {
+    if ($Matches[1] -ne $apiLevel) {
+        Write-Error "Failed to set repo.json DalamudApiLevel to $apiLevel"
+        exit 1
+    }
+} else {
+    Write-Error "Could not find DalamudApiLevel in $repoJsonPath"
+    exit 1
+}
+Write-Output "Set repo.json DalamudApiLevel to $apiLevel"
 $unixNow = [long]([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())
 $repoJson = $repoJson -replace '("LastUpdated":\s*)\d+', "`${1}$unixNow"
 Set-Content $repoJsonPath -Value $repoJson -NoNewline

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -31,22 +31,40 @@ for f in "$CSPROJ" "$REPO_JSON" "$MANIFEST"; do
 done
 
 # 1) Bump version in csproj
-if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
-  sed -i "s/<AssemblyVersion>[^<]*<\\/AssemblyVersion>/<AssemblyVersion>$VERSION<\\/AssemblyVersion>/" "$CSPROJ"
+if grep -q '<Version>[^<]*</Version>' "$CSPROJ"; then
+  VERSION_TAG="Version"
+elif grep -q '<AssemblyVersion>[^<]*</AssemblyVersion>' "$CSPROJ"; then
+  VERSION_TAG="AssemblyVersion"
 else
-  sed -i.bak "s/<AssemblyVersion>[^<]*<\\/AssemblyVersion>/<AssemblyVersion>$VERSION<\\/AssemblyVersion>/" "$CSPROJ" && rm -f "${CSPROJ}.bak"
+  echo "Error: could not find <Version> or <AssemblyVersion> in $CSPROJ" >&2
+  exit 1
 fi
-echo "Set SaddlebagExchange.csproj AssemblyVersion to $VERSION"
+if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
+  sed -i "s/<$VERSION_TAG>[^<]*<\\/$VERSION_TAG>/<$VERSION_TAG>$VERSION<\\/$VERSION_TAG>/" "$CSPROJ"
+else
+  sed -i.bak "s/<$VERSION_TAG>[^<]*<\\/$VERSION_TAG>/<$VERSION_TAG>$VERSION<\\/$VERSION_TAG>/" "$CSPROJ" && rm -f "${CSPROJ}.bak"
+fi
+echo "Set SaddlebagExchange.csproj $VERSION_TAG to $VERSION"
 
-# 2) Bump version and LastUpdated in repo.json
+# 2) Bump version, API level, and LastUpdated in repo.json
+API_LEVEL=$(grep -oE 'Dalamud\.NET\.Sdk/[0-9]+' "$CSPROJ" | head -n1 | sed 's|.*/||')
 if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
   sed -i "s/\"AssemblyVersion\": \"[^\"]*\"/\"AssemblyVersion\": \"$VERSION\"/" "$REPO_JSON"
+  if [[ -n "$API_LEVEL" ]]; then
+    sed -i "s/\"DalamudApiLevel\": [0-9]*/\"DalamudApiLevel\": $API_LEVEL/" "$REPO_JSON"
+  fi
   UNIX_NOW=$(date +%s 2>/dev/null || echo "0")
   sed -i "s/\"LastUpdated\": [0-9]*/\"LastUpdated\": $UNIX_NOW/" "$REPO_JSON"
 else
   sed -i.bak "s/\"AssemblyVersion\": \"[^\"]*\"/\"AssemblyVersion\": \"$VERSION\"/" "$REPO_JSON" && rm -f "${REPO_JSON}.bak"
+  if [[ -n "$API_LEVEL" ]]; then
+    sed -i.bak "s/\"DalamudApiLevel\": [0-9]*/\"DalamudApiLevel\": $API_LEVEL/" "$REPO_JSON" && rm -f "${REPO_JSON}.bak"
+  fi
   UNIX_NOW=$(date +%s 2>/dev/null || echo "0")
   sed -i.bak "s/\"LastUpdated\": [0-9]*/\"LastUpdated\": $UNIX_NOW/" "$REPO_JSON" && rm -f "${REPO_JSON}.bak"
+fi
+if [[ -n "$API_LEVEL" ]]; then
+  echo "Set repo.json DalamudApiLevel to $API_LEVEL"
 fi
 echo "Set repo.json AssemblyVersion to $VERSION and LastUpdated to $UNIX_NOW"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,24 +48,26 @@ echo "Set SaddlebagExchange.csproj $VERSION_TAG to $VERSION"
 
 # 2) Bump version, API level, and LastUpdated in repo.json
 API_LEVEL=$(grep -oE 'Dalamud\.NET\.Sdk/[0-9]+' "$CSPROJ" | head -n1 | sed 's|.*/||')
+if [[ -z "$API_LEVEL" ]]; then
+  echo "Error: could not derive DalamudApiLevel from Dalamud.NET.Sdk in $CSPROJ" >&2
+  exit 1
+fi
+if ! grep -q '"DalamudApiLevel"' "$REPO_JSON"; then
+  echo "Error: no DalamudApiLevel key in $REPO_JSON" >&2
+  exit 1
+fi
 if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
   sed -i "s/\"AssemblyVersion\": \"[^\"]*\"/\"AssemblyVersion\": \"$VERSION\"/" "$REPO_JSON"
-  if [[ -n "$API_LEVEL" ]]; then
-    sed -i "s/\"DalamudApiLevel\": [0-9]*/\"DalamudApiLevel\": $API_LEVEL/" "$REPO_JSON"
-  fi
+  sed -i "s/\"DalamudApiLevel\": [0-9]*/\"DalamudApiLevel\": $API_LEVEL/" "$REPO_JSON"
   UNIX_NOW=$(date +%s 2>/dev/null || echo "0")
   sed -i "s/\"LastUpdated\": [0-9]*/\"LastUpdated\": $UNIX_NOW/" "$REPO_JSON"
 else
   sed -i.bak "s/\"AssemblyVersion\": \"[^\"]*\"/\"AssemblyVersion\": \"$VERSION\"/" "$REPO_JSON" && rm -f "${REPO_JSON}.bak"
-  if [[ -n "$API_LEVEL" ]]; then
-    sed -i.bak "s/\"DalamudApiLevel\": [0-9]*/\"DalamudApiLevel\": $API_LEVEL/" "$REPO_JSON" && rm -f "${REPO_JSON}.bak"
-  fi
+  sed -i.bak "s/\"DalamudApiLevel\": [0-9]*/\"DalamudApiLevel\": $API_LEVEL/" "$REPO_JSON" && rm -f "${REPO_JSON}.bak"
   UNIX_NOW=$(date +%s 2>/dev/null || echo "0")
   sed -i.bak "s/\"LastUpdated\": [0-9]*/\"LastUpdated\": $UNIX_NOW/" "$REPO_JSON" && rm -f "${REPO_JSON}.bak"
 fi
-if [[ -n "$API_LEVEL" ]]; then
-  echo "Set repo.json DalamudApiLevel to $API_LEVEL"
-fi
+echo "Set repo.json DalamudApiLevel to $API_LEVEL"
 echo "Set repo.json AssemblyVersion to $VERSION and LastUpdated to $UNIX_NOW"
 
 # 3) Restore manifest.toml so it cannot be accidentally included

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -67,6 +67,10 @@ else
   UNIX_NOW=$(date +%s 2>/dev/null || echo "0")
   sed -i.bak "s/\"LastUpdated\": [0-9]*/\"LastUpdated\": $UNIX_NOW/" "$REPO_JSON" && rm -f "${REPO_JSON}.bak"
 fi
+if ! grep -Eq "\"DalamudApiLevel\"[[:space:]]*:[[:space:]]*$API_LEVEL([[:space:]]*[,}])" "$REPO_JSON"; then
+  echo "Error: failed to set DalamudApiLevel to $API_LEVEL in $REPO_JSON" >&2
+  exit 1
+fi
 echo "Set repo.json DalamudApiLevel to $API_LEVEL"
 echo "Set repo.json AssemblyVersion to $VERSION and LastUpdated to $UNIX_NOW"
 


### PR DESCRIPTION
## Summary
- align the plugin project version and custom repo API level with the current Dalamud SDK 15 release state
- update release scripts to mutate the current `<Version>` property and derive `DalamudApiLevel` from `Dalamud.NET.Sdk/<major>`
- prevent older background search completions from overwriting newer results in Reselling, Marketshare, Craftsim, and Shopping List

## Why
The release feed advertised `AssemblyVersion` 1.0.19 and API level 14 while the project built with SDK 15 and still declared project `Version` 1.0.16. The old release scripts looked for `<AssemblyVersion>`, so version bumps could silently miss the project file.

The search tabs also launched fire-and-forget work where a slower older request could finish after a newer one and replace the current UI state. Each search now gets a generation token, and stale completions or stale errors are ignored.

## Validation
- `git diff --check`
- `repo.json` parsed locally and reports `AssemblyVersion: 1.0.19`, `DalamudApiLevel: 15`
- `scripts/release.ps1` parses as PowerShell
- installed local .NET SDK `10.0.203`
- downloaded `goatcorp/dalamud-distrib` `latest.zip` and set `DALAMUD_HOME`
- `dotnet restore SaddlebagExchange/SaddlebagExchange.csproj`
- `dotnet build SaddlebagExchange/SaddlebagExchange.csproj -c Release --no-incremental -o release_output` passed with 0 warnings and 0 errors
- generated `SaddlebagExchange.json` reports `AssemblyVersion: 1.0.19.0` and `DalamudApiLevel: 15`

Not verified in a live FFXIV/Dalamud client from this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale async scan/search results from overwriting current UI state during concurrent requests or disposal.

* **Chores**
  * Bumped project version to 1.0.19.
  * Updated API compatibility level to the next target.
  * Enhanced release scripts to reliably update version and API level fields and validate updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->