### PR TITLE
[codex] Harden external links and cache world list

### DIFF
--- a/SaddlebagExchange/UI/CraftsimTab.cs
+++ b/SaddlebagExchange/UI/CraftsimTab.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
-using Dalamud.Utility;
 using SaddlebagExchange.Models;
 using SaddlebagExchange.Services;
 
@@ -970,8 +969,7 @@ namespace SaddlebagExchange.UI
 
         private static void OpenUrl(string? url)
         {
-            if (string.IsNullOrEmpty(url)) return;
-            Util.OpenLink(url);
+            ExternalLinkHelper.OpenHttpUrl(url);
         }
 
         public void Dispose()

--- a/SaddlebagExchange/UI/ExternalLinkHelper.cs
+++ b/SaddlebagExchange/UI/ExternalLinkHelper.cs
@@ -17,7 +17,7 @@ namespace SaddlebagExchange.UI
             if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
                 return;
 
-            Util.OpenLink(uri.ToString());
+            Util.OpenLink(uri.AbsoluteUri);
         }
     }
 }

--- a/SaddlebagExchange/UI/ExternalLinkHelper.cs
+++ b/SaddlebagExchange/UI/ExternalLinkHelper.cs
@@ -1,0 +1,23 @@
+using System;
+using Dalamud.Utility;
+
+namespace SaddlebagExchange.UI
+{
+    internal static class ExternalLinkHelper
+    {
+        public static void OpenHttpUrl(string? url)
+        {
+            var value = url?.Trim();
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            if (!Uri.TryCreate(value, UriKind.Absolute, out var uri))
+                return;
+
+            if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+                return;
+
+            Util.OpenLink(uri.ToString());
+        }
+    }
+}

--- a/SaddlebagExchange/UI/MarketshareTab.cs
+++ b/SaddlebagExchange/UI/MarketshareTab.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
-using Dalamud.Utility;
 using SaddlebagExchange.Models;
 using SaddlebagExchange.Services;
 
@@ -558,8 +557,7 @@ namespace SaddlebagExchange.UI
 
         private static void OpenUrl(string? url)
         {
-            if (string.IsNullOrEmpty(url)) return;
-            Util.OpenLink(url);
+            ExternalLinkHelper.OpenHttpUrl(url);
         }
 
         private void DrawCell(MarketshareResultItem row, int colId)

--- a/SaddlebagExchange/UI/ResellingSearchTab.cs
+++ b/SaddlebagExchange/UI/ResellingSearchTab.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
-using Dalamud.Utility;
 using SaddlebagExchange.Models;
 using SaddlebagExchange.Services;
 
@@ -335,8 +334,7 @@ namespace SaddlebagExchange.UI
 
         private static void OpenUrl(string? url)
         {
-            if (string.IsNullOrEmpty(url)) return;
-            Util.OpenLink(url);
+            ExternalLinkHelper.OpenHttpUrl(url);
         }
 
         private static string FormatTimestamp(string? ms)

--- a/SaddlebagExchange/UI/WorldList.cs
+++ b/SaddlebagExchange/UI/WorldList.cs
@@ -11,10 +11,10 @@ namespace SaddlebagExchange.UI
     /// </summary>
     public static class WorldList
     {
-        private static readonly Lazy<(string DataCenter, string World)[]> AllLazy = new(GetAll);
+        private static readonly Lazy<(string DataCenter, string World)[]> AllLazy = new(BuildAll);
 
         /// <summary>Data centers and worlds supported by Saddlebag. Keep in sync with saddlebag-with-pockets Worlds.ts.</summary>
-        public static (string DataCenter, string World)[] GetAll()
+        private static (string DataCenter, string World)[] BuildAll()
         {
             return new[]
             {
@@ -107,6 +107,9 @@ namespace SaddlebagExchange.UI
         }
 
         public static (string DataCenter, string World)[] All => AllLazy.Value;
+
+        /// <summary>Data centers and worlds supported by Saddlebag. Keep in sync with saddlebag-with-pockets Worlds.ts.</summary>
+        public static (string DataCenter, string World)[] GetAll() => All;
 
         /// <summary>Unique data center names in display order.</summary>
         public static string[] GetDataCenters()

--- a/SaddlebagExchange/UI/WorldList.cs
+++ b/SaddlebagExchange/UI/WorldList.cs
@@ -106,9 +106,12 @@ namespace SaddlebagExchange.UI
             };
         }
 
-        public static (string DataCenter, string World)[] All => AllLazy.Value;
+        private static (string DataCenter, string World)[] CachedAll => AllLazy.Value;
 
-        /// <summary>Data centers and worlds supported by Saddlebag. Keep in sync with saddlebag-with-pockets Worlds.ts.</summary>
+        /// <summary>Copy of data centers and worlds supported by Saddlebag. Keep in sync with saddlebag-with-pockets Worlds.ts.</summary>
+        public static (string DataCenter, string World)[] All => ((string DataCenter, string World)[])CachedAll.Clone();
+
+        /// <summary>Copy of data centers and worlds supported by Saddlebag. Keep in sync with saddlebag-with-pockets Worlds.ts.</summary>
         public static (string DataCenter, string World)[] GetAll() => All;
 
         /// <summary>Unique data center names in display order.</summary>
@@ -116,7 +119,7 @@ namespace SaddlebagExchange.UI
         {
             var seen = new HashSet<string>();
             var list = new List<string>();
-            foreach (var (dc, _) in All)
+            foreach (var (dc, _) in CachedAll)
             {
                 if (seen.Add(dc))
                     list.Add(dc);
@@ -128,7 +131,7 @@ namespace SaddlebagExchange.UI
         public static string[] GetWorlds(string dataCenter)
         {
             var list = new List<string>();
-            foreach (var (dc, world) in All)
+            foreach (var (dc, world) in CachedAll)
             {
                 if (dc == dataCenter)
                     list.Add(world);
@@ -140,7 +143,7 @@ namespace SaddlebagExchange.UI
         public static string? GetDataCenterForWorld(string world)
         {
             if (string.IsNullOrEmpty(world)) return null;
-            foreach (var (dc, w) in All)
+            foreach (var (dc, w) in CachedAll)
             {
                 if (string.Equals(w, world, StringComparison.OrdinalIgnoreCase))
                     return dc;


### PR DESCRIPTION
## Summary
- add a shared helper that only opens absolute http(s) URLs from API-provided result links
- route Reselling, Marketshare, and Craftsim external result links through that helper
- keep `WorldList.GetAll()` on the lazy cached world list instead of rebuilding the array on direct calls

## Why
These are low-risk, non-blocking cleanup items from the earlier Dalamud/GitHub review history. Valid `http://` and `https://` links continue to open normally, while empty, malformed, or non-http(s) values are ignored as defense in depth.

## Validation
- `git diff --check` passed, with only Windows line-ending warnings
- `dotnet build SaddlebagExchange/SaddlebagExchange.csproj -c Release --no-incremental -o release_output` passed with 0 warnings and 0 errors
- generated `SaddlebagExchange.json` reports `AssemblyVersion: 1.0.19.0` and `DalamudApiLevel: 15`
- removed `release_output` after validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated URL handling with HTTP/HTTPS scheme validation for improved link security.
  * Reorganized world list data initialization for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->